### PR TITLE
fix barter_ui.script:119 crash

### DIFF
--- a/gamedata/configs/gameplay/dialogs_barter_ui.xml
+++ b/gamedata/configs/gameplay/dialogs_barter_ui.xml
@@ -11,7 +11,7 @@
             <phrase id="1"> <!-- npc -->
                 <script_text>barter_core.st_barter_answer</script_text>
                 <action>barter_ui.start</action>
-                <action>dialogs.break_dialog</action>
+                <!-- <action>dialogs.break_dialog</action> -->
             </phrase>
         </phrase_list>
     </dialog>


### PR DESCRIPTION
fixed barter_ui.script:119: attempt to index local 'npc' (a nil value)